### PR TITLE
Imprecisioni righe 138, 141

### DIFF
--- a/forms/segnala_document_data_embed.html
+++ b/forms/segnala_document_data_embed.html
@@ -135,10 +135,10 @@ lang: en
           'Address 1': 'Indirizzo 1',
           'Address 2': 'Indirizzo 2',
           'City': 'Città',
-          'State': 'Stato',
+          'State': 'Provincia',
           'Country': 'Paese',
           'Zip Code': 'CAP',
-          'I confirm to have read and accepted privacy informative to threat personal data': 'Confermo di aver letto e accetto l\'informativa sulla privacy per il trattamento dei dati personali',
+          'I confirm that I have read the privacy policy and consent to the treatment of personal data': 'Confermo di aver letto e accetto l\'informativa sulla privacy per il trattamento dei dati personali',
           'Submit': 'Invia' 
       }
     }


### PR DESCRIPTION
la riga 141 presentava una frase in inglese per il trattamento dei dati personali [typo= threat invece di treatment]. Ho girato la frase e resa più efficace
la riga 138 traduceva State con Stato e non con Provincia